### PR TITLE
Add core YouTube API layers, Hilt setup, and API-key-only feature scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,64 @@
 # YoutubeAndroid
-(WIP) This repository shows implementation all Youtube API features
- <h3>✅ Play Youtube Videos</h3> 
- <h3>⬜️ YouTube Data API v3 (Play Youtube Live Video & chat)</h3><h4>(https://developers.google.com/youtube/v3/getting-started?hl=en_US)</h4>
- <h3>⬜️ Youtube Analytics API</h3><h4>(https://developers.google.com/youtube/analytics?hl=en_US)</h4>
- <h3>⬜️ Youtube Reporting API</h3><h4>(https://developers.google.com/youtube/reporting/v1/reports/?hl=en_US)</h4>
- <h3>⬜️ Youtube oEmbed API</h3><h4>(https://youtube-eng.googleblog.com/2009/10/oembed-support_9.html)</h4>
- <h3>⬜️ Configure Subscribe buttons</h3><h4>(https://developers.google.com/youtube/youtube_subscribe_button)</h4>
- <h3>⬜️ Live Streaming</h3><h4>(https://developers.google.com/youtube/v3/live/getting-started)</h4>
+
+A Kotlin Android reference project for developers who want to integrate the YouTube Data API v3 without starting from raw documentation.
+
+The project is intentionally split into two learning paths:
+
+1. **API_KEY_ONLY** — public data features that work with a YouTube Data API key and do not require user login.
+2. **OAUTH_REQUIRED** — account-scoped features that require Google Sign-In / OAuth 2.0 user consent.
+
+## Project goals
+
+- Demonstrate every major YouTube Data API v3 feature in a practical Android app.
+- Keep every feature self-contained with its own repository, ViewModel/UI state where applicable, and README.
+- Use Kotlin, MVVM, Repository pattern, Coroutines, Flow, Retrofit, Moshi, OkHttp, and Hilt.
+- Provide clean error handling and comments for the API-specific details that usually slow Android developers down.
+
+## Current implementation status
+
+### API_KEY_ONLY
+
+- ✅ Search videos, channels, and playlists
+- ✅ Fetch video details and metadata
+- ✅ Get channel info and stats
+- ✅ Browse public playlists and playlist items
+- ✅ Get video categories and supported regions
+
+### OAUTH_REQUIRED
+
+- ⬜ Upload videos
+- ⬜ Live streaming: create, manage, and transition broadcast states
+- ⬜ Live chat: read and post messages
+- ⬜ Post and delete comments
+- ⬜ Manage playlists: create playlists, add videos, remove videos
+- ⬜ Subscribe and unsubscribe to channels
+- ⬜ Manage captions
+
+## API key setup
+
+Add your YouTube Data API key to `~/.gradle/gradle.properties` or the project `gradle.properties` file:
+
+```properties
+YT_API_KEY=your_api_key_here
+```
+
+The app exposes this value as `BuildConfig.YOUTUBE_API_KEY` and appends it to API-key-only requests through `ApiKeyInterceptor`.
+
+## Package map
+
+```text
+app/src/main/java/com/akshayashokcode/youtubeandroid/
+├── core/
+│   ├── model/          # Shared YouTube response DTOs
+│   ├── network/        # Retrofit API and API-key interceptor
+│   ├── result/         # Result wrapper for repositories
+│   └── ui/             # Shared UI state model
+├── di/                 # Hilt modules
+└── features/
+    ├── apikeyonly/     # Public API-key-only examples
+    └── oauthrequired/  # OAuth feature guides and future implementations
+```
+
+## Feature folders
+
+Each feature folder contains the code and README needed to understand that feature in isolation. Start with `features/apikeyonly/search` for the smallest end-to-end MVVM example.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name=".YoutubeAndroidApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/MainActivity.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/MainActivity.kt
@@ -1,8 +1,10 @@
 package com.akshayashokcode.youtubeandroid
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/YoutubeAndroidApp.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/YoutubeAndroidApp.kt
@@ -1,0 +1,7 @@
+package com.akshayashokcode.youtubeandroid
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class YoutubeAndroidApp : Application()

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/core/model/YouTubeModels.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/core/model/YouTubeModels.kt
@@ -1,0 +1,277 @@
+package com.akshayashokcode.youtubeandroid.core.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PageInfo(
+    val totalResults: Int? = null,
+    val resultsPerPage: Int? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class Thumbnail(
+    val url: String? = null,
+    val width: Int? = null,
+    val height: Int? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class Thumbnails(
+    @Json(name = "default") val defaultThumbnail: Thumbnail? = null,
+    val medium: Thumbnail? = null,
+    val high: Thumbnail? = null,
+    val standard: Thumbnail? = null,
+    val maxres: Thumbnail? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class LocalizedText(
+    val title: String? = null,
+    val description: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class SearchListResponse(
+    val nextPageToken: String? = null,
+    val prevPageToken: String? = null,
+    val regionCode: String? = null,
+    val pageInfo: PageInfo? = null,
+    val items: List<SearchResult> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class SearchResult(
+    val id: SearchId? = null,
+    val snippet: Snippet? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class SearchId(
+    val kind: String? = null,
+    val videoId: String? = null,
+    val channelId: String? = null,
+    val playlistId: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class VideoListResponse(
+    val nextPageToken: String? = null,
+    val prevPageToken: String? = null,
+    val pageInfo: PageInfo? = null,
+    val items: List<Video> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class Video(
+    val id: String? = null,
+    val snippet: Snippet? = null,
+    val contentDetails: VideoContentDetails? = null,
+    val statistics: VideoStatistics? = null,
+    val status: VideoStatus? = null,
+    val liveStreamingDetails: LiveStreamingDetails? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class VideoContentDetails(
+    val duration: String? = null,
+    val dimension: String? = null,
+    val definition: String? = null,
+    val caption: String? = null,
+    val licensedContent: Boolean? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class VideoStatistics(
+    val viewCount: String? = null,
+    val likeCount: String? = null,
+    val favoriteCount: String? = null,
+    val commentCount: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class VideoStatus(
+    val uploadStatus: String? = null,
+    val privacyStatus: String? = null,
+    val license: String? = null,
+    val embeddable: Boolean? = null,
+    val publicStatsViewable: Boolean? = null,
+    val madeForKids: Boolean? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class LiveStreamingDetails(
+    val actualStartTime: String? = null,
+    val actualEndTime: String? = null,
+    val scheduledStartTime: String? = null,
+    val scheduledEndTime: String? = null,
+    val concurrentViewers: String? = null,
+    val activeLiveChatId: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ChannelListResponse(
+    val nextPageToken: String? = null,
+    val prevPageToken: String? = null,
+    val pageInfo: PageInfo? = null,
+    val items: List<Channel> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class Channel(
+    val id: String? = null,
+    val snippet: Snippet? = null,
+    val contentDetails: ChannelContentDetails? = null,
+    val statistics: ChannelStatistics? = null,
+    val brandingSettings: BrandingSettings? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ChannelContentDetails(
+    val relatedPlaylists: RelatedPlaylists? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class RelatedPlaylists(
+    val likes: String? = null,
+    val uploads: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ChannelStatistics(
+    val viewCount: String? = null,
+    val subscriberCount: String? = null,
+    val hiddenSubscriberCount: Boolean? = null,
+    val videoCount: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class BrandingSettings(
+    val channel: BrandingChannel? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class BrandingChannel(
+    val title: String? = null,
+    val description: String? = null,
+    val keywords: String? = null,
+    val country: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class PlaylistListResponse(
+    val nextPageToken: String? = null,
+    val prevPageToken: String? = null,
+    val pageInfo: PageInfo? = null,
+    val items: List<Playlist> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class Playlist(
+    val id: String? = null,
+    val snippet: Snippet? = null,
+    val contentDetails: PlaylistContentDetails? = null,
+    val status: PlaylistStatus? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class PlaylistContentDetails(
+    val itemCount: Int? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class PlaylistStatus(
+    val privacyStatus: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class PlaylistItemListResponse(
+    val nextPageToken: String? = null,
+    val prevPageToken: String? = null,
+    val pageInfo: PageInfo? = null,
+    val items: List<PlaylistItem> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class PlaylistItem(
+    val id: String? = null,
+    val snippet: PlaylistItemSnippet? = null,
+    val contentDetails: PlaylistItemContentDetails? = null,
+    val status: PlaylistStatus? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class PlaylistItemSnippet(
+    val publishedAt: String? = null,
+    val channelId: String? = null,
+    val title: String? = null,
+    val description: String? = null,
+    val thumbnails: Thumbnails? = null,
+    val channelTitle: String? = null,
+    val playlistId: String? = null,
+    val position: Int? = null,
+    val resourceId: ResourceId? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ResourceId(
+    val kind: String? = null,
+    val videoId: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class PlaylistItemContentDetails(
+    val videoId: String? = null,
+    val videoPublishedAt: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class VideoCategoryListResponse(
+    val items: List<VideoCategory> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class VideoCategory(
+    val id: String? = null,
+    val snippet: VideoCategorySnippet? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class VideoCategorySnippet(
+    val title: String? = null,
+    val assignable: Boolean? = null,
+    val channelId: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class RegionListResponse(
+    val items: List<Region> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class Region(
+    val id: String? = null,
+    val snippet: RegionSnippet? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class RegionSnippet(
+    val gl: String? = null,
+    val name: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class Snippet(
+    val publishedAt: String? = null,
+    val channelId: String? = null,
+    val title: String? = null,
+    val description: String? = null,
+    val thumbnails: Thumbnails? = null,
+    val channelTitle: String? = null,
+    val tags: List<String>? = null,
+    val categoryId: String? = null,
+    val liveBroadcastContent: String? = null,
+    val localized: LocalizedText? = null,
+    val defaultLanguage: String? = null,
+    val defaultAudioLanguage: String? = null,
+)

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/core/network/ApiKeyInterceptor.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/core/network/ApiKeyInterceptor.kt
@@ -1,0 +1,23 @@
+package com.akshayashokcode.youtubeandroid.core.network
+
+import com.akshayashokcode.youtubeandroid.BuildConfig
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+class ApiKeyInterceptor @Inject constructor() : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+        val apiKey = BuildConfig.YOUTUBE_API_KEY
+
+        if (apiKey.isBlank()) {
+            return chain.proceed(originalRequest)
+        }
+
+        val urlWithKey = originalRequest.url.newBuilder()
+            .addQueryParameter("key", apiKey)
+            .build()
+
+        return chain.proceed(originalRequest.newBuilder().url(urlWithKey).build())
+    }
+}

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/core/network/YouTubeApiService.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/core/network/YouTubeApiService.kt
@@ -1,0 +1,75 @@
+package com.akshayashokcode.youtubeandroid.core.network
+
+import com.akshayashokcode.youtubeandroid.core.model.ChannelListResponse
+import com.akshayashokcode.youtubeandroid.core.model.PlaylistItemListResponse
+import com.akshayashokcode.youtubeandroid.core.model.PlaylistListResponse
+import com.akshayashokcode.youtubeandroid.core.model.RegionListResponse
+import com.akshayashokcode.youtubeandroid.core.model.SearchListResponse
+import com.akshayashokcode.youtubeandroid.core.model.VideoCategoryListResponse
+import com.akshayashokcode.youtubeandroid.core.model.VideoListResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface YouTubeApiService {
+    @GET("youtube/v3/search")
+    suspend fun search(
+        @Query("part") part: String = YouTubeParts.SEARCH,
+        @Query("q") query: String,
+        @Query("type") type: String? = null,
+        @Query("channelId") channelId: String? = null,
+        @Query("pageToken") pageToken: String? = null,
+        @Query("maxResults") maxResults: Int = 25,
+    ): SearchListResponse
+
+    @GET("youtube/v3/videos")
+    suspend fun videos(
+        @Query("part") part: String = YouTubeParts.VIDEOS,
+        @Query("id") ids: String? = null,
+        @Query("chart") chart: String? = null,
+        @Query("regionCode") regionCode: String? = null,
+        @Query("videoCategoryId") videoCategoryId: String? = null,
+        @Query("pageToken") pageToken: String? = null,
+        @Query("maxResults") maxResults: Int = 25,
+    ): VideoListResponse
+
+    @GET("youtube/v3/channels")
+    suspend fun channels(
+        @Query("part") part: String = YouTubeParts.CHANNELS,
+        @Query("id") ids: String? = null,
+        @Query("forUsername") username: String? = null,
+        @Query("mine") mine: Boolean? = null,
+        @Query("pageToken") pageToken: String? = null,
+        @Query("maxResults") maxResults: Int = 25,
+    ): ChannelListResponse
+
+    @GET("youtube/v3/playlists")
+    suspend fun playlists(
+        @Query("part") part: String = YouTubeParts.PLAYLISTS,
+        @Query("id") ids: String? = null,
+        @Query("channelId") channelId: String? = null,
+        @Query("mine") mine: Boolean? = null,
+        @Query("pageToken") pageToken: String? = null,
+        @Query("maxResults") maxResults: Int = 25,
+    ): PlaylistListResponse
+
+    @GET("youtube/v3/playlistItems")
+    suspend fun playlistItems(
+        @Query("part") part: String = YouTubeParts.PLAYLIST_ITEMS,
+        @Query("playlistId") playlistId: String,
+        @Query("pageToken") pageToken: String? = null,
+        @Query("maxResults") maxResults: Int = 25,
+    ): PlaylistItemListResponse
+
+    @GET("youtube/v3/videoCategories")
+    suspend fun videoCategories(
+        @Query("part") part: String = YouTubeParts.CATEGORIES,
+        @Query("regionCode") regionCode: String? = null,
+        @Query("id") ids: String? = null,
+    ): VideoCategoryListResponse
+
+    @GET("youtube/v3/i18nRegions")
+    suspend fun regions(
+        @Query("part") part: String = YouTubeParts.REGIONS,
+        @Query("hl") language: String? = null,
+    ): RegionListResponse
+}

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/core/network/YouTubeParts.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/core/network/YouTubeParts.kt
@@ -1,0 +1,11 @@
+package com.akshayashokcode.youtubeandroid.core.network
+
+object YouTubeParts {
+    const val SEARCH = "snippet"
+    const val VIDEOS = "snippet,contentDetails,statistics,status,liveStreamingDetails"
+    const val CHANNELS = "snippet,contentDetails,statistics,brandingSettings"
+    const val PLAYLISTS = "snippet,contentDetails,status"
+    const val PLAYLIST_ITEMS = "snippet,contentDetails,status"
+    const val CATEGORIES = "snippet"
+    const val REGIONS = "snippet"
+}

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/core/result/AppResult.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/core/result/AppResult.kt
@@ -1,0 +1,16 @@
+package com.akshayashokcode.youtubeandroid.core.result
+
+import kotlinx.coroutines.CancellationException
+
+sealed interface AppResult<out T> {
+    data class Success<T>(val data: T) : AppResult<T>
+    data class Error(val throwable: Throwable, val message: String = throwable.message.orEmpty()) : AppResult<Nothing>
+}
+
+inline fun <T> runAppCatching(block: () -> T): AppResult<T> = try {
+    AppResult.Success(block())
+} catch (throwable: CancellationException) {
+    throw throwable
+} catch (throwable: Throwable) {
+    AppResult.Error(throwable)
+}

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/core/ui/UiState.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/core/ui/UiState.kt
@@ -1,0 +1,8 @@
+package com.akshayashokcode.youtubeandroid.core.ui
+
+sealed interface UiState<out T> {
+    data object Idle : UiState<Nothing>
+    data object Loading : UiState<Nothing>
+    data class Data<T>(val value: T) : UiState<T>
+    data class Error(val message: String) : UiState<Nothing>
+}

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/di/NetworkModule.kt
@@ -1,0 +1,52 @@
+package com.akshayashokcode.youtubeandroid.di
+
+import com.akshayashokcode.youtubeandroid.core.network.ApiKeyInterceptor
+import com.akshayashokcode.youtubeandroid.core.network.YouTubeApiService
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+    private const val GOOGLE_APIS_BASE_URL = "https://www.googleapis.com/"
+
+    @Provides
+    @Singleton
+    fun provideMoshi(): Moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(apiKeyInterceptor: ApiKeyInterceptor): OkHttpClient {
+        val logging = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BASIC
+        }
+
+        return OkHttpClient.Builder()
+            .addInterceptor(apiKeyInterceptor)
+            .addInterceptor(logging)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideYouTubeApiService(
+        okHttpClient: OkHttpClient,
+        moshi: Moshi,
+    ): YouTubeApiService = Retrofit.Builder()
+        .baseUrl(GOOGLE_APIS_BASE_URL)
+        .client(okHttpClient)
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .build()
+        .create(YouTubeApiService::class.java)
+}

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/README.md
@@ -1,0 +1,18 @@
+# API_KEY_ONLY features
+
+These examples call public YouTube Data API v3 endpoints with a server-issued API key. They do not require Google Sign-In and should be the first section developers explore.
+
+## Implemented folders
+
+- `search` — searches videos, channels, and playlists with `search.list`.
+- `video_details` — fetches metadata, statistics, status, and live details with `videos.list`.
+- `channel_info` — fetches channel metadata, branding, upload playlist IDs, and stats with `channels.list`.
+- `public_playlists` — reads public playlists and playlist items with `playlists.list` and `playlistItems.list`.
+- `categories_regions` — reads video categories and supported i18n regions.
+
+## Common flow
+
+1. Repository calls `YouTubeApiService`.
+2. Retrofit suspending function executes on the caller coroutine.
+3. Repository emits `AppResult` through Flow.
+4. ViewModel maps `AppResult` into `UiState` for UI rendering.

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/categories_regions/CategoriesRegionsRepository.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/categories_regions/CategoriesRegionsRepository.kt
@@ -1,0 +1,22 @@
+package com.akshayashokcode.youtubeandroid.features.apikeyonly.categories_regions
+
+import com.akshayashokcode.youtubeandroid.core.model.RegionListResponse
+import com.akshayashokcode.youtubeandroid.core.model.VideoCategoryListResponse
+import com.akshayashokcode.youtubeandroid.core.network.YouTubeApiService
+import com.akshayashokcode.youtubeandroid.core.result.AppResult
+import com.akshayashokcode.youtubeandroid.core.result.runAppCatching
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class CategoriesRegionsRepository @Inject constructor(
+    private val service: YouTubeApiService,
+) {
+    fun getVideoCategories(regionCode: String = "US"): Flow<AppResult<VideoCategoryListResponse>> = flow {
+        emit(runAppCatching { service.videoCategories(regionCode = regionCode) })
+    }
+
+    fun getSupportedRegions(language: String? = null): Flow<AppResult<RegionListResponse>> = flow {
+        emit(runAppCatching { service.regions(language = language) })
+    }
+}

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/categories_regions/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/categories_regions/README.md
@@ -1,0 +1,8 @@
+# Get video categories and regions
+
+Demonstrates public metadata endpoints that help build region-aware YouTube experiences.
+
+## Supports
+
+- `videoCategories.list` for assignable video categories in a region.
+- `i18nRegions.list` for YouTube-supported regions.

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/channel_info/ChannelInfoRepository.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/channel_info/ChannelInfoRepository.kt
@@ -1,0 +1,27 @@
+package com.akshayashokcode.youtubeandroid.features.apikeyonly.channel_info
+
+import com.akshayashokcode.youtubeandroid.core.model.ChannelListResponse
+import com.akshayashokcode.youtubeandroid.core.network.YouTubeApiService
+import com.akshayashokcode.youtubeandroid.core.result.AppResult
+import com.akshayashokcode.youtubeandroid.core.result.runAppCatching
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class ChannelInfoRepository @Inject constructor(
+    private val service: YouTubeApiService,
+) {
+    fun getChannelsById(channelIds: List<String>): Flow<AppResult<ChannelListResponse>> = flow {
+        emit(
+            runAppCatching {
+                val ids = channelIds.filter(String::isNotBlank).joinToString(",")
+                require(ids.isNotBlank()) { "At least one channel ID is required." }
+                service.channels(ids = ids)
+            },
+        )
+    }
+
+    fun getChannelByUsername(username: String): Flow<AppResult<ChannelListResponse>> = flow {
+        emit(runAppCatching { service.channels(username = username) })
+    }
+}

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/channel_info/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/channel_info/README.md
@@ -1,0 +1,9 @@
+# Get channel info and stats
+
+Demonstrates `channels.list` for public channel details.
+
+## Supports
+
+- Fetch channels by ID.
+- Fetch a channel by legacy username.
+- Reads snippets, upload playlist IDs, statistics, and branding settings.

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/public_playlists/PublicPlaylistsRepository.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/public_playlists/PublicPlaylistsRepository.kt
@@ -1,0 +1,28 @@
+package com.akshayashokcode.youtubeandroid.features.apikeyonly.public_playlists
+
+import com.akshayashokcode.youtubeandroid.core.model.PlaylistItemListResponse
+import com.akshayashokcode.youtubeandroid.core.model.PlaylistListResponse
+import com.akshayashokcode.youtubeandroid.core.network.YouTubeApiService
+import com.akshayashokcode.youtubeandroid.core.result.AppResult
+import com.akshayashokcode.youtubeandroid.core.result.runAppCatching
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class PublicPlaylistsRepository @Inject constructor(
+    private val service: YouTubeApiService,
+) {
+    fun getPublicPlaylistsForChannel(
+        channelId: String,
+        pageToken: String? = null,
+    ): Flow<AppResult<PlaylistListResponse>> = flow {
+        emit(runAppCatching { service.playlists(channelId = channelId, pageToken = pageToken) })
+    }
+
+    fun getPlaylistItems(
+        playlistId: String,
+        pageToken: String? = null,
+    ): Flow<AppResult<PlaylistItemListResponse>> = flow {
+        emit(runAppCatching { service.playlistItems(playlistId = playlistId, pageToken = pageToken) })
+    }
+}

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/public_playlists/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/public_playlists/README.md
@@ -1,0 +1,9 @@
+# Browse public playlists
+
+Demonstrates public playlist browsing.
+
+## Supports
+
+- `playlists.list` for public playlists on a channel.
+- `playlistItems.list` for the videos inside a playlist.
+- Pagination with `pageToken`.

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/search/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/search/README.md
@@ -1,0 +1,15 @@
+# Search videos, channels, and playlists
+
+Demonstrates `search.list` for public YouTube search.
+
+## Supports
+
+- Free-text search with `q`.
+- Optional result type filtering: `video`, `channel`, or `playlist`.
+- Optional channel-scoped search with `channelId`.
+- Pagination with `pageToken`.
+
+## Android pattern
+
+- `SearchRepository` wraps the Retrofit call and exposes `Flow<AppResult<SearchListResponse>>`.
+- `SearchViewModel` validates input and maps repository results into `UiState`.

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/search/SearchRepository.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/search/SearchRepository.kt
@@ -1,0 +1,37 @@
+package com.akshayashokcode.youtubeandroid.features.apikeyonly.search
+
+import com.akshayashokcode.youtubeandroid.core.model.SearchListResponse
+import com.akshayashokcode.youtubeandroid.core.network.YouTubeApiService
+import com.akshayashokcode.youtubeandroid.core.result.AppResult
+import com.akshayashokcode.youtubeandroid.core.result.runAppCatching
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class SearchRepository @Inject constructor(
+    private val service: YouTubeApiService,
+) {
+    fun search(
+        query: String,
+        type: SearchType? = null,
+        channelId: String? = null,
+        pageToken: String? = null,
+    ): Flow<AppResult<SearchListResponse>> = flow {
+        emit(
+            runAppCatching {
+                service.search(
+                    query = query,
+                    type = type?.apiValue,
+                    channelId = channelId,
+                    pageToken = pageToken,
+                )
+            },
+        )
+    }
+}
+
+enum class SearchType(val apiValue: String) {
+    Video("video"),
+    Channel("channel"),
+    Playlist("playlist"),
+}

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/search/SearchViewModel.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/search/SearchViewModel.kt
@@ -1,0 +1,40 @@
+package com.akshayashokcode.youtubeandroid.features.apikeyonly.search
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.akshayashokcode.youtubeandroid.core.model.SearchListResponse
+import com.akshayashokcode.youtubeandroid.core.result.AppResult
+import com.akshayashokcode.youtubeandroid.core.ui.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchViewModel @Inject constructor(
+    private val repository: SearchRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow<UiState<SearchListResponse>>(UiState.Idle)
+    val uiState: StateFlow<UiState<SearchListResponse>> = _uiState.asStateFlow()
+
+    fun search(query: String, type: SearchType? = null) {
+        if (query.isBlank()) {
+            _uiState.value = UiState.Error("Enter a search query.")
+            return
+        }
+
+        viewModelScope.launch {
+            repository.search(query = query.trim(), type = type)
+                .onStart { _uiState.value = UiState.Loading }
+                .collect { result ->
+                    _uiState.value = when (result) {
+                        is AppResult.Success -> UiState.Data(result.data)
+                        is AppResult.Error -> UiState.Error(result.message.ifBlank { "Search failed." })
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/video_details/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/video_details/README.md
@@ -1,0 +1,9 @@
+# Fetch video details and metadata
+
+Demonstrates `videos.list` for public video metadata.
+
+## Supports
+
+- Fetch details for one or more video IDs.
+- Fetch most popular videos by region and optional category.
+- Reads common parts: `snippet`, `contentDetails`, `statistics`, `status`, and `liveStreamingDetails`.

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/video_details/VideoDetailsRepository.kt
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/apikeyonly/video_details/VideoDetailsRepository.kt
@@ -1,0 +1,40 @@
+package com.akshayashokcode.youtubeandroid.features.apikeyonly.video_details
+
+import com.akshayashokcode.youtubeandroid.core.model.VideoListResponse
+import com.akshayashokcode.youtubeandroid.core.network.YouTubeApiService
+import com.akshayashokcode.youtubeandroid.core.result.AppResult
+import com.akshayashokcode.youtubeandroid.core.result.runAppCatching
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class VideoDetailsRepository @Inject constructor(
+    private val service: YouTubeApiService,
+) {
+    fun getVideoDetails(videoIds: List<String>): Flow<AppResult<VideoListResponse>> = flow {
+        emit(
+            runAppCatching {
+                val ids = videoIds.filter(String::isNotBlank).joinToString(",")
+                require(ids.isNotBlank()) { "At least one video ID is required." }
+                service.videos(ids = ids)
+            },
+        )
+    }
+
+    fun getPopularVideos(
+        regionCode: String = "US",
+        videoCategoryId: String? = null,
+        pageToken: String? = null,
+    ): Flow<AppResult<VideoListResponse>> = flow {
+        emit(
+            runAppCatching {
+                service.videos(
+                    chart = "mostPopular",
+                    regionCode = regionCode,
+                    videoCategoryId = videoCategoryId,
+                    pageToken = pageToken,
+                )
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/README.md
@@ -1,0 +1,20 @@
+# OAUTH_REQUIRED features
+
+These examples require Google Sign-In / OAuth 2.0 because they read or mutate a user's YouTube account. API keys are not enough for these operations.
+
+## Planned folders
+
+- `upload_videos` — resumable uploads, privacy status, title, description, tags, and thumbnails.
+- `live_streaming` — broadcast creation, stream binding, health checks, and lifecycle transitions.
+- `live_chat` — read live chat messages, post messages, and handle polling intervals.
+- `comments` — insert, moderate, and delete comment threads/comments.
+- `manage_playlists` — create playlists and add/remove playlist items.
+- `subscriptions` — subscribe and unsubscribe from channels.
+- `captions` — list, upload, download, update, and delete caption tracks.
+
+## OAuth implementation plan
+
+1. Add Google Sign-In and request the smallest scopes needed by each feature.
+2. Store account/session state outside feature repositories.
+3. Inject an authenticated HTTP client that adds `Authorization: Bearer <access_token>`.
+4. Keep account-specific samples separate from API-key-only samples to avoid confusing quota, auth, and consent requirements.

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/captions/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/captions/README.md
@@ -1,0 +1,14 @@
+# Captions
+
+OAuth-required feature guide.
+
+## Scope
+
+List, upload, download, update, and delete caption tracks.
+
+## Implementation notes
+
+- Requires Google Sign-In and a fresh access token.
+- Should use the smallest YouTube OAuth scope needed for the operation.
+- Must surface API quota errors, permission errors, and user-revoked-consent errors clearly.
+- Keep request/response models and repositories in this folder when implemented.

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/comments/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/comments/README.md
@@ -1,0 +1,14 @@
+# Comments
+
+OAuth-required feature guide.
+
+## Scope
+
+Post, list, moderate, and delete comments/comment threads with account-scoped permissions.
+
+## Implementation notes
+
+- Requires Google Sign-In and a fresh access token.
+- Should use the smallest YouTube OAuth scope needed for the operation.
+- Must surface API quota errors, permission errors, and user-revoked-consent errors clearly.
+- Keep request/response models and repositories in this folder when implemented.

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/live_chat/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/live_chat/README.md
@@ -1,0 +1,14 @@
+# Live chat
+
+OAuth-required feature guide.
+
+## Scope
+
+Read live chat messages, respect polling intervals, post chat messages, and handle disabled/ended chat states.
+
+## Implementation notes
+
+- Requires Google Sign-In and a fresh access token.
+- Should use the smallest YouTube OAuth scope needed for the operation.
+- Must surface API quota errors, permission errors, and user-revoked-consent errors clearly.
+- Keep request/response models and repositories in this folder when implemented.

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/live_streaming/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/live_streaming/README.md
@@ -1,0 +1,14 @@
+# Live streaming
+
+OAuth-required feature guide.
+
+## Scope
+
+Create unlisted broadcasts, bind streams, monitor health, transition states, and surface live chat IDs.
+
+## Implementation notes
+
+- Requires Google Sign-In and a fresh access token.
+- Should use the smallest YouTube OAuth scope needed for the operation.
+- Must surface API quota errors, permission errors, and user-revoked-consent errors clearly.
+- Keep request/response models and repositories in this folder when implemented.

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/manage_playlists/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/manage_playlists/README.md
@@ -1,0 +1,14 @@
+# Manage playlists
+
+OAuth-required feature guide.
+
+## Scope
+
+Create playlists, add videos, reorder items, and remove videos from playlists.
+
+## Implementation notes
+
+- Requires Google Sign-In and a fresh access token.
+- Should use the smallest YouTube OAuth scope needed for the operation.
+- Must surface API quota errors, permission errors, and user-revoked-consent errors clearly.
+- Keep request/response models and repositories in this folder when implemented.

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/subscriptions/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/subscriptions/README.md
@@ -1,0 +1,14 @@
+# Subscriptions
+
+OAuth-required feature guide.
+
+## Scope
+
+Subscribe and unsubscribe to channels with explicit user consent.
+
+## Implementation notes
+
+- Requires Google Sign-In and a fresh access token.
+- Should use the smallest YouTube OAuth scope needed for the operation.
+- Must surface API quota errors, permission errors, and user-revoked-consent errors clearly.
+- Keep request/response models and repositories in this folder when implemented.

--- a/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/upload_videos/README.md
+++ b/app/src/main/java/com/akshayashokcode/youtubeandroid/features/oauthrequired/upload_videos/README.md
@@ -1,0 +1,14 @@
+# Upload videos
+
+OAuth-required feature guide.
+
+## Scope
+
+Resumable upload flow, metadata, privacy status, tags, thumbnails, and post-upload verification.
+
+## Implementation notes
+
+- Requires Google Sign-In and a fresh access token.
+- Should use the smallest YouTube OAuth scope needed for the operation.
+- Must surface API quota errors, permission errors, and user-revoked-consent errors clearly.
+- Keep request/response models and repositories in this folder when implemented.


### PR DESCRIPTION
### Motivation

- Provide a complete, opinionated Kotlin Android reference for integrating the YouTube Data API v3 with clear separation between API-key-only features and OAuth-required features.
- Introduce shared models, networking, result/UI wrappers, DI, and example repositories to make each feature self-contained and easy to learn.

### Description

- Added app-level Hilt setup by introducing `YoutubeAndroidApp` annotated with `@HiltAndroidApp`, added `android:name=".YoutubeAndroidApp"` to the `AndroidManifest.xml`, and annotated `MainActivity` with `@AndroidEntryPoint`.
- Implemented JSON models in `core/model/YouTubeModels.kt`, result and UI wrappers in `core/result/AppResult.kt` and `core/ui/UiState.kt`, and a query-parameter `ApiKeyInterceptor` in `core/network/ApiKeyInterceptor.kt`.
- Implemented Retrofit service `YouTubeApiService`, `YouTubeParts` constants, and a `NetworkModule` that provides `Moshi`, an `OkHttpClient` with logging and the API-key interceptor, and a configured Retrofit instance.
- Added API-key-only feature scaffolding with repositories and README docs for `search`, `video_details`, `channel_info`, `public_playlists`, and `categories_regions`, plus high-level guides for planned `oauthrequired` features.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0038de1830832fa63987907a54254d)